### PR TITLE
把search.java里面InputStreamReader的charset改成了"UTF-8"

### DIFF
--- a/src/main/java/Search.java
+++ b/src/main/java/Search.java
@@ -22,7 +22,7 @@ public class Search implements Callable {
         String line = null;
         while (!findIt) {
             URL url = new URL(path);
-            BufferedReader breaded = new BufferedReader(new InputStreamReader(url.openStream()));
+            BufferedReader breaded = new BufferedReader(new InputStreamReader(url.openStream(),"UTF-8"));
             while ((line = breaded.readLine()) != null) {
                 if (line.contains("百度为您找到相关结果约")) {
                     findIt = true;


### PR DESCRIPTION
我的url.openStream()返回的是"UTF-8"编码的字符串，匹配“百度为您找到相关结果约”总是不成功。
改为"UTF-8"后运行正常